### PR TITLE
Exclude 4 glaciers from the crossvalidation for the moment

### DIFF
--- a/mbcrossval/crossvalidation.py
+++ b/mbcrossval/crossvalidation.py
@@ -275,6 +275,14 @@ def initialization_selection():
     # Sort for more efficient parallel computing
     rgidf = rgidf.sort_values('Area', ascending=False)
 
+    # some glaciers do not work with certain parameter combinations right now.
+    # Will try to catch them later, but just exclude them for no
+    rgidf = rgidf.loc[rgidf.RGIId != 'RGI60-16.01638']
+    rgidf = rgidf.loc[rgidf.RGIId != 'RGI60-17.14871']
+    rgidf = rgidf.loc[rgidf.RGIId != 'RGI60-03.01623']
+    rgidf = rgidf.loc[rgidf.RGIId != 'RGI60-17.14868']
+    rgidf = rgidf.loc[rgidf.RGIId != 'RGI60-17.14874']
+
     # Go - initialize working directories
     gdirs = workflow.init_glacier_regions(rgidf, reset=True, force=True)
 


### PR DESCRIPTION
Some glaciers do not work with certain parameter combinations right now.
I will try to catch them later within the crossvalidation, but just exclude them for now.