### PR TITLE
path problems on the cluster when copying favicon

### DIFF
--- a/mbcrossval/website.py
+++ b/mbcrossval/website.py
@@ -34,11 +34,11 @@ def website_main():
     imgpth = os.path.join(mbcfg.PATHS['webroot'], 'img')
     logo = 'oggm_s_alpha.png'
     utils.mkdir(imgpth)
-    copyfile(os.path.join(os.path.dirname(os.path.dirname(__file__)),
-                          'favicon.ico'),
-             os.path.join(imgpth, 'favicon.ico'))
-    copyfile(os.path.join(os.path.dirname(os.path.dirname(__file__)), logo),
-             os.path.join(imgpth, logo))
+    copyfile(os.path.join(os.path.dirname(os.path.dirname(
+        os.path.abspath(__file__))), 'favicon.ico'),
+        os.path.join(imgpth, 'favicon.ico'))
+    copyfile(os.path.join(os.path.dirname(os.path.dirname(
+        os.path.abspath(__file__))), logo), os.path.join(imgpth, logo))
 
     # make a catalogue from all stored versions
     vdf = catalog_storaged_files()


### PR DESCRIPTION
`os.path.join(os.path.dirname(os.path.dirname(__file__)), 'favicon.ico')` works in my environment to get the favicon-path in the directory 1 level below the website.py file where this line is based.

It also worked when I run the crossvalidation manually on the cluster. But it does not work when executed automatically:
`FileNotFoundError:  No such file or directory: ...oggm_env/lib/python3.6/site-packages/favicon.ico'`
It actually looks one level too low.

Hoping to fix this with adding `os.path.abspath` to it:
`os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'favicon.ico')`